### PR TITLE
build: use everoute/docpars:0.2.0-alpine as base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,4 @@
-FROM alpine:3.15
-
-RUN apk add --no-cache bash curl jq wget
-RUN mkdir -p "$HOME/bin" && \
-    cd "$HOME/bin" && \
-    wget https://github.com/denisidoro/docpars/releases/download/v0.2.0/docpars-v0.2.0-x86_64-unknown-linux-musl.tar.gz && tar xvfz docpars-v0.2.0-x86_64-unknown-linux-musl.tar.gz -C ./ && \
-    chmod +x docpars
+FROM everoute/docpars:0.2.0-alpine
 
 ADD entrypoint.sh /entrypoint.sh
 ADD src /src


### PR DESCRIPTION
https://hub.docker.com/r/everoute/docpars